### PR TITLE
Add caching of the JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
-exports.checkMessage = async function (message) {
-  let checkMessage = require("./lib/check");
-  let isTokengrabber = await checkMessage.check(message);
-  return isTokengrabber;
-};
+const check = require("./lib/check");
+const list = require("./lib/list");
 
-exports.listDomains = async function () {
-  let list = require("./lib/list");
-  return await list.getDomains();
-};
+exports.checkMessage = check.checkMessage;
+
+exports.listDomains = list.listDomains;

--- a/lib/check.js
+++ b/lib/check.js
@@ -1,9 +1,12 @@
-exports.check = async function (message) {
-  let list = require("./list");
-  let domains = await list.getDomains();
+const list = require("./list");
+
+exports.checkMessage = async function checkMessage(message) {
+  let domains = await list.listDomains();
+
   const susDomainsChecker = (arg) =>
     domains.some((domains) => arg.includes(domains));
-  const susDomainsArgs = message.toLowerCase().split(/ +/);
-  const susDomainsMatching = susDomainsArgs.filter(susDomainsChecker);
-  return susDomainsMatching.length ? true : false;
+
+  const susDomainsArgs = message.toLowerCase().split(/\s+/);
+
+  return susDomainsArgs.some(susDomainsChecker);
 };

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,7 +1,15 @@
 const axios = require("axios").default;
-exports.getDomains = async function getList() {
-  const url =
-    "https://raw.githubusercontent.com/nikolaischunk/discord-phishing-links/main/domain-list.json";
-  const list = await axios.get(url);
-  return list.data.domains;
+
+const URL = "https://raw.githubusercontent.com/nikolaischunk/discord-phishing-links/main/domain-list.json";
+const CACHE_DURATION = 1000 * 3600;
+
+let cache_date = 0;
+let cache = null;
+
+exports.listDomains = async function listDomains() {
+  if (cache === null || Date.now() - cache_date > CACHE_DURATION) {
+    cache = (await axios.get(URL)).data;
+    cache_date = Date.now();
+  }
+  return cache.domains;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stop-discord-phishing",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A simple Package that adds functionality with Discord Tokkenloggers Links to prevent scams & phishing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The script currently downloads the JSON of the domains on every call to `checkMessage` or `listDomains`. On my machine, this causes a ~200ms delay before the message can be analyzed, so this would equates to a maximum of ~5 analysis per second if network transfer was the main bottleneck.

This PR adds a small cache in `list.js`, which currently lasts one hour. The first call to `checkMessage` still takes a while to download the JSON, but any subsequent call will be near-instantaneous.

I also changed the name of the functions, as to make them more consistent (they are all either `checkMessage` or `listDomains`). The functions in `index.js` were identities, so I swapped them out to simply re-export the functions in `check.js` and `list.js`.

Finally, I replaced the `array.filter(...).length > 0` with `array.some(...)`.

I didn't intend to get this merged when I made this commit, so sorry if it bundles a lot of changes. Feel free to only merge parts of it.