### PR TITLE
Add support for suspicious domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,3 +4,4 @@ const list = require("./lib/list");
 exports.checkMessage = check.checkMessage;
 
 exports.listDomains = list.listDomains;
+exports.listSuspicious = list.listSuspicious;

--- a/lib/check.js
+++ b/lib/check.js
@@ -1,10 +1,19 @@
 const list = require("./list");
 
-exports.checkMessage = async function checkMessage(message) {
+exports.checkMessage = async function checkMessage(message, scanSuspiciousDomains = false) {
   let domains = await list.listDomains();
+  let suspiciousDomains = scanSuspiciousDomains ? await list.listSuspicious() : null;
 
-  const susDomainsChecker = (arg) =>
-    domains.some((domains) => arg.includes(domains));
+  function susDomainsChecker(arg) {
+    if (domains.some((domains) => arg.includes(domains))) {
+      return true;
+    } else if (scanSuspiciousDomains) {
+      if (suspiciousDomains.some((domain) => arg.includes(domain))) {
+        return true;
+      }
+    }
+    return false;
+  };
 
   const susDomainsArgs = message.toLowerCase().split(/\s+/);
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,15 +1,33 @@
 const axios = require("axios").default;
 
-const URL = "https://raw.githubusercontent.com/nikolaischunk/discord-phishing-links/main/domain-list.json";
+const URL_GUARANTEED = "https://raw.githubusercontent.com/nikolaischunk/discord-phishing-links/main/domain-list.json";
+const URL_SUSPICIOUS = "https://raw.githubusercontent.com/nikolaischunk/discord-phishing-links/main/suspicious-list.json";
 const CACHE_DURATION = 1000 * 60 * 30; // 30 minutes
 
 let cache_date = 0;
 let cache = null;
 
-exports.listDomains = async function listDomains() {
+async function update_cache() {
   if (cache === null || Date.now() - cache_date > CACHE_DURATION) {
-    cache = (await axios.get(URL)).data;
+    let promises = await Promise.all([
+      axios.get(URL_GUARANTEED),
+      axios.get(URL_SUSPICIOUS)
+    ]);
+    cache = {
+      guaranteed: promises[0].data,
+      suspicious: promises[1].data
+    };
     cache_date = Date.now();
   }
-  return cache.domains;
+}
+
+
+exports.listDomains = async function listDomains() {
+  await update_cache();
+  return cache.guaranteed.domains;
 };
+
+exports.listSuspicious = async function listSuspicious() {
+  await update_cache();
+  return cache.suspicious.domains;
+}


### PR DESCRIPTION
Commit [7e08f092](https://github.com/nikolaischunk/discord-phishing-links/commit/7e08f09279f9b2663754193cccc16ee03676dd13) over on `discord-phishing-links` split the database into two halves: the domains confirmed to be associated with phishing (`domain-list.json`) and the domains suspected to have been associated with phishing (`suspicious-list.json`).

This PR contains code to support querying either the confirmed database or the confirmed+suspicious database.

Because this is a major change, I'd advise to bump the `package.json` version to `0.1.0` instead of `0.0.5`