### PR TITLE
Match domains in the message and prevent false positives.

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -4,23 +4,20 @@ exports.checkMessage = async function checkMessage(message, scanSuspiciousDomain
   let domains = await list.listDomains();
   let suspiciousDomains = scanSuspiciousDomains ? await list.listSuspicious() : null;
 
-  function checkDomain(domainToCheck, susDomain)
-  {
+  function checkDomain(domainToCheck, susDomain) {
     const checkPath = /\/[^\s]+/;
 
     // Lets check if the susDomain has a path
-    if (checkPath.test(susDomain))
-    {
+    if (checkPath.test(susDomain)) {
       // If so then check for an exact match
       return domainToCheck[1] === susDomain;
     }
-    else
-    {
+    else {
       // If not then check just the domain
       return domainToCheck[2] === susDomain;
     }
   }
-  
+
   function susDomainsChecker(arg) {
     if (domains.some((domain) => checkDomain(arg, domain))) {
       return true;
@@ -42,7 +39,7 @@ exports.checkMessage = async function checkMessage(message, scanSuspiciousDomain
   const regex = /(?:(?:https?|ftp|mailto):\/\/)?(?:www\.)?(([^\/\s]+\.[a-z\.]+)(\/[^\s]*)?)(?:\/)?/ig;
 
   let m;
-  
+
   // Extract all the matched urls
   while ((m = regex.exec(message.toLowerCase())) !== null) {
     if (m.index === regex.lastIndex) {

--- a/lib/check.js
+++ b/lib/check.js
@@ -5,17 +5,36 @@ exports.checkMessage = async function checkMessage(message, scanSuspiciousDomain
   let suspiciousDomains = scanSuspiciousDomains ? await list.listSuspicious() : null;
 
   function susDomainsChecker(arg) {
-    if (domains.some((domains) => arg.includes(domains))) {
+    if (domains.some((domain) => arg.endsWith(domain))) {
       return true;
     } else if (scanSuspiciousDomains) {
-      if (suspiciousDomains.some((domain) => arg.includes(domain))) {
+      if (suspiciousDomains.some((domain) => arg.endsWith(domain))) {
         return true;
       }
     }
     return false;
   };
 
-  const susDomainsArgs = message.toLowerCase().split(/\s+/);
+  var susDomainsArgs = [];
+
+  // https://stackoverflow.com/questions/6038061/regular-expression-to-find-urls-within-a-string#comment110332325_6041965
+  const regex = /((http|ftp|https)\:\/\/)?([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?/g;
+
+  let m;
+
+  // Extract all the matched urls
+  while ((m = regex.exec(message.toLowerCase())) !== null) {
+    if (m.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+
+    m.forEach((match, groupIndex) => {
+      // Extract the domain
+      if (groupIndex == 3) {
+        susDomainsArgs.push(match);
+      }
+    });
+  }
 
   return susDomainsArgs.some(susDomainsChecker);
 };

--- a/lib/check.js
+++ b/lib/check.js
@@ -4,11 +4,28 @@ exports.checkMessage = async function checkMessage(message, scanSuspiciousDomain
   let domains = await list.listDomains();
   let suspiciousDomains = scanSuspiciousDomains ? await list.listSuspicious() : null;
 
+  function checkDomain(domainToCheck, susDomain)
+  {
+    const checkPath = /\/[^\s]+/;
+
+    // Lets check if the susDomain has a path
+    if (checkPath.test(susDomain))
+    {
+      // If so then check for an exact match
+      return domainToCheck[1] === susDomain;
+    }
+    else
+    {
+      // If not then check just the domain
+      return domainToCheck[2] === susDomain;
+    }
+  }
+  
   function susDomainsChecker(arg) {
-    if (domains.some((domain) => arg.endsWith(domain))) {
+    if (domains.some((domain) => checkDomain(arg, domain))) {
       return true;
     } else if (scanSuspiciousDomains) {
-      if (suspiciousDomains.some((domain) => arg.endsWith(domain))) {
+      if (suspiciousDomains.some((domain) => checkDomain(arg, domain))) {
         return true;
       }
     }
@@ -17,23 +34,22 @@ exports.checkMessage = async function checkMessage(message, scanSuspiciousDomain
 
   var susDomainsArgs = [];
 
-  // https://stackoverflow.com/questions/6038061/regular-expression-to-find-urls-within-a-string#comment110332325_6041965
-  const regex = /((http|ftp|https)\:\/\/)?([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?/g;
+  // Match urls only
+  // Example: https://discordapp.com/test/
+  // Group 1: domain + path (discordapp.com/test)
+  // Group 2: domain (discordapp.com)
+  // Group 3: path (/test)
+  const regex = /(?:(?:https?|ftp|mailto):\/\/)?(?:www\.)?(([^\/\s]+\.[a-z\.]+)(\/[^\s]*)?)(?:\/)?/ig;
 
   let m;
-
+  
   // Extract all the matched urls
   while ((m = regex.exec(message.toLowerCase())) !== null) {
     if (m.index === regex.lastIndex) {
       regex.lastIndex++;
     }
 
-    m.forEach((match, groupIndex) => {
-      // Extract the domain
-      if (groupIndex == 3) {
-        susDomainsArgs.push(match);
-      }
-    });
+    susDomainsArgs.push(m);
   }
 
   return susDomainsArgs.some(susDomainsChecker);


### PR DESCRIPTION
Match all the domains from the string and check if they end with one of the flagged domains.
This allows us to includes domains like 'discordapp.co'.
This is an initial PR the strings also include sub domains and an exact match would be better instead of checking that their end matches.
We should probably just get the second level + top level and do an exact match of it or include all the sub domains in the list.