### PR TITLE
Fixed JavaScript SyntaxError

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ async function checkMessage (message) {
   return isGrabber
 }
 
-async function checkMessageFull (message, true) {
+async function checkMessageFull (message, True) {
   //check string on confirmed & not yet confirmed but suspicious Phishing Domains
   let isGrabber = await stopPhishing.checkMessage(message)
   //Now you can do something with the Boolean Value


### PR DESCRIPTION
Ah yes here I am again with yet another pointless change.. I have changed the true on line 65 in the Readme file to True because true with a lowercase t returns a SyntaxError