### PR TITLE
Addition of .toString() in line 44

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -41,7 +41,7 @@ exports.checkMessage = async function checkMessage(message, scanSuspiciousDomain
   let m;
 
   // Extract all the matched urls
-  while ((m = regex.exec(message.toLowerCase())) !== null) {
+  while ((m = regex.exec(message.toString().toLowerCase())) !== null) {
     if (m.index === regex.lastIndex) {
       regex.lastIndex++;
     }


### PR DESCRIPTION
I originally tried out the default version of line 44 (which was message.toLowerCase()), and my bot crashed. So I did some quick digging around and found out that there actually should be .toString() in the middle of "message" and ".toLowercase()". I tried it out and it works beautifully.