### PR TITLE
Fix list.listSuspicious and list.listDomains is not a function

### DIFF
--- a/lib/amount.js
+++ b/lib/amount.js
@@ -5,7 +5,7 @@ const list = require("./list");
  * @returns {number} The number of detected domains
  */
 exports.phishingDomainCount = async function phishingDomainCount() {
-  let domains = await list.listDomains();
+  let domains = await list.listPhishingDomains();
   return domains.length;
 };
 
@@ -14,7 +14,7 @@ exports.phishingDomainCount = async function phishingDomainCount() {
  * @returns {number} The number of suspicious domains
  */
 exports.suspiciousDomainCount = async function suspiciousDomainCount() {
-  let domains = await list.listSuspicious();
+  let domains = await list.listSuspiciousDomains();
   return domains.length;
 };
 


### PR DESCRIPTION
fixes the error list.listSuspicious and list.listDomains is not a function when calling the functions described in the example

listPhishingDomains();
listSuspiciousDomains();